### PR TITLE
Add ISO mapper prototype engine and API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 *.rar
 *.tar
 *.zip
+node_modules/
+dist/
+package-lock.json
 
 # Logs and databases #
 ######################

--- a/README.md
+++ b/README.md
@@ -1,94 +1,110 @@
-<header>
+# ISO Mapper & Message Modeling Prototype
 
-<!--
-  <<< Author notes: Course header >>>
-  Read <https://skills.github.com/quickstart> for more information about how to build courses using this template.
-  Include a 1280×640 image, course name in sentence case, and a concise description in emphasis.
-  In your repository settings: enable template repository, add your 1280×640 social image, auto delete head branches.
-  Next to "About", add description & tags; disable releases, packages, & environments.
-  Add your open source license, GitHub uses the MIT license.
--->
+This repository contains a small, config-driven mapping engine and HTTP API prototype. It demonstrates how message layouts, field definitions, and mapping rules can be described with YAML files and executed at runtime without any vendor-specific coupling.
 
-# Code with GitHub Copilot
+The engine loads definitions from the `definitions/` directory, validates mapping sets, executes transform functions, and exposes an Express-based API for inspection and execution.
 
-_GitHub Copilot can help you code by offering autocomplete-style suggestions right in VS Code and Codespaces._
+## Getting started
 
-</header>
-
-<!--
-  <<< Author notes: Step 1 >>>
-  Choose 3-5 steps for your course.
-  The first step is always the hardest, so pick something easy!
-  Link to docs.github.com for further explanations.
-  Encourage users to open new tabs for steps!
--->
-
-## Step 1: Leverage Codespaces with VS Code for Copilot
-
-_Welcome to "Develop With AI Powered Code Suggestions Using GitHub Copilot and VS Code"! :wave:_
-
-GitHub Copilot is an AI pair programmer that helps you write code faster and with less work. It draws context from comments and code to suggest individual lines and whole functions instantly. GitHub Copilot is powered by OpenAI Codex, a generative pretrained language model created by OpenAI.
-
-**Copilot works with many code editors including VS Code, Visual Studio, JetBrains IDE, and Neovim.**
-
-Additionally, GitHub Copilot is trained on all languages that appear in public repositories. For each language, the quality of suggestions you receive may depend on the volume and diversity of training data for that language.
-
-Using Copilot inside a Codespace shows just how easy it is to get up and running with GitHub's suite of [Collaborative Coding](https://github.com/features#features-collaboration) tools.
-
-> **Note**
-> This skills exercise will focus on leveraging GitHub Codespace. It is recommended that you complete the GitHub skill, [Codespaces](https://github.com/skills/code-with-codespaces), before moving forward with this exercise.
-
-### :keyboard: Activity: Enable Copilot inside a Codespace
-
-**We recommend opening another browser tab to work through the following activities so you can keep these instructions open for reference.**
-
-Before you open up a codespace on a repository, you can create a development container and define specific extensions or configurations that will be used or installed in your codespace. Let's create this development container and add copilot to the list of extensions.
-
-1. Navigating back to your **Code** tab of your repository, click the **Add file** drop-down button, and then click `Create new file`.
-1. Type or paste the following in the empty text field prompt to name your file.
+1. Install dependencies:
+   ```bash
+   npm install
    ```
-   .devcontainer/devcontainer.json
+2. Compile the TypeScript sources:
+   ```bash
+   npm run build
    ```
-1. In the body of the new **.devcontainer/devcontainer.json** file, add the following content:
+3. Start the HTTP API:
+   ```bash
+   npm start
    ```
-   {
-       // Name this configuration
-       "name": "Codespace for Skills!",
-       "customizations": {
-           "vscode": {
-               "extensions": [
-                   "GitHub.copilot"
-               ]
-           }
-       }
-   }
-   ```
-1. Select the option to **Commit directly to the `main` branch**, and then click the **Commit new file** button.
-1. Navigate back to the home page of your repository by clicking the **Code** tab located at the top left of the screen.
-1. Click the **Code** button located in the middle of the page.
-1. Click the **Codespaces** tab on the box that pops up.
-1. Click the **Create codespace on main** button.
+   The server listens on port `3000` by default. Use the `PORT` environment variable to override the port.
 
-   **Wait about 2 minutes for the codespace to spin itself up.**
+During development you can use:
+```bash
+npm run dev
+```
+which starts the server directly with `ts-node`.
 
-1. Verify your codespace is running. The browser should contain a VS Code web-based editor and a terminal should be present such as the below:
-   ![Screen Shot 2023-03-09 at 9 09 07 AM](https://user-images.githubusercontent.com/26442605/224102962-d0222578-3f10-4566-856d-8d59f28fcf2e.png)
-1. The `copilot` extension should show up in the VS Code extension list. Click the extensions sidebar tab. You should see the following:
-   ![Screen Shot 2023-03-09 at 9 04 13 AM](https://user-images.githubusercontent.com/26442605/224102514-7d6d2f51-f435-401d-a529-7bae3ae3e511.png)
+## Definitions directory
 
-**Wait about 60 seconds then refresh your repository landing page for the next step.**
+The prototype ships with a set of proof-of-concept definitions:
 
-<footer>
+- `definitions/fields.yaml` – shared field catalogue.
+- `definitions/messages/` – message layouts for source and target messages.
+- `definitions/mappings/` – mapping rules that connect the messages.
 
-<!--
-  <<< Author notes: Footer >>>
-  Add a link to get support, GitHub status page, code of conduct, license link.
--->
+All files can be authored in either YAML or JSON. On startup the engine builds in-memory indexes for fields, messages, and mapping sets.
 
----
+## HTTP API
 
-Get help: [Post in our discussion board](https://github.com/orgs/skills/discussions/categories/code-with-copilot) &bull; [Review the GitHub status page](https://www.githubstatus.com/)
+| Endpoint | Description |
+| --- | --- |
+| `GET /health` | Liveness probe returning `{ "status": "ok" }`. |
+| `GET /mappings/:id` | Returns the raw mapping set definition. |
+| `POST /validate/:id` | Validates the mapping set identified by `id` and returns configuration errors or warnings. |
+| `POST /run` | Executes a mapping set using the logical JSON payload supplied in the request body. |
 
-&copy; 2023 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
+### Example `POST /run`
 
-</footer>
+Request body:
+```json
+{
+  "mapping_set_id": "iso8583_auth_to_internal_v1",
+  "input": {
+    "mti": "0100",
+    "pan": "6011000990139424",
+    "amount_minor": 10000,
+    "currency_numeric": "840",
+    "stan": "123456",
+    "merchant_number": "M123456789",
+    "acceptor_id": "TERM001",
+    "auth_code": "",
+    "txn_timestamp": "2025-11-09T12:34:56Z"
+  }
+}
+```
+
+Example response snippet:
+```json
+{
+  "valid": true,
+  "output": {
+    "mti": "0100",
+    "stan": "123456",
+    "txn_timestamp": "2025-11-09T12:34:56Z",
+    "pan": "6011000990139424",
+    "bin": "601100",
+    "amount_minor": 10000,
+    "currency_alpha": "USD",
+    "auth_code": "",
+    "merchant_id": "M123456789",
+    "channel": "POS",
+    "approval_status": "PENDING",
+    "response_code": "00"
+  },
+  "warnings": [],
+  "errors": [],
+  "trace": [
+    { "ruleId": "rule_mti", "type": "direct", "fromField": "mti", "toField": "mti" },
+    { "ruleId": "rule_bin", "type": "transform", "fromField": "pan", "toField": "bin", "transformFn": "derive_bin" },
+    { "ruleId": "rule_channel", "type": "conditional", "toField": "channel" }
+  ]
+}
+```
+
+Warnings are non-blocking and do not prevent the `valid` flag from being `true`. The `trace` array records each rule that participated in the execution.
+
+## Transform registry
+
+The MVP transform registry bundles a few utility functions for demonstration purposes:
+
+- `minor_to_major(value, { scale })`
+- `iso4217_numeric_to_alpha(value)`
+- `derive_bin(pan, { length })`
+
+You can extend the registry by editing `src/transformRegistry.ts` and referencing the new function names inside mapping definitions.
+
+## Running tests
+
+This prototype does not yet include automated tests. Mapping behaviour can be validated via the `/run` endpoint or by importing the executor modules directly in your own scripts.

--- a/definitions/fields.yaml
+++ b/definitions/fields.yaml
@@ -1,0 +1,74 @@
+- id: mti
+  label: Message Type Indicator
+  type: string
+  description: ISO8583 message type indicator
+- id: pan
+  label: Primary Account Number
+  type: string
+  constraints:
+    min_length: 12
+    max_length: 19
+- id: amount_minor
+  label: Amount in Minor Units
+  type: integer
+  description: Transaction amount represented in minor currency units
+- id: currency_numeric
+  label: ISO4217 Numeric Currency Code
+  type: string
+  constraints:
+    length: 3
+- id: stan
+  label: System Trace Audit Number
+  type: string
+  constraints:
+    length: 6
+- id: auth_code
+  label: Authorization Code
+  type: string
+  constraints:
+    max_length: 8
+- id: merchant_number
+  label: Merchant Number
+  type: string
+- id: acceptor_id
+  label: Acceptor ID
+  type: string
+- id: txn_timestamp
+  label: Transaction Timestamp
+  type: datetime
+- id: bin
+  label: Bank Identification Number
+  type: string
+  constraints:
+    min_length: 6
+    max_length: 8
+- id: currency_alpha
+  label: ISO4217 Alpha Currency Code
+  type: string
+  constraints:
+    length: 3
+- id: merchant_id
+  label: Merchant Identifier
+  type: string
+- id: channel
+  label: Merchant Channel
+  type: string
+  constraints:
+    enum:
+      - POS
+      - ECOM
+      - MOTO
+      - UNKNOWN
+- id: approval_status
+  label: Approval Status
+  type: string
+  constraints:
+    enum:
+      - APPROVED
+      - DECLINED
+      - PENDING
+- id: response_code
+  label: Response Code
+  type: string
+  constraints:
+    length: 2

--- a/definitions/mappings/iso8583_auth_to_internal_v1.yaml
+++ b/definitions/mappings/iso8583_auth_to_internal_v1.yaml
@@ -1,0 +1,80 @@
+id: iso8583_auth_to_internal_v1
+description: Map ISO8583 authorization requests into internal payment requests
+from_message: discover_iso8583_auth_v1
+to_message: internal_payment_v1
+version: "1.0"
+mappings:
+  - id: rule_mti
+    from:
+      field: mti
+    to:
+      field: mti
+  - id: rule_stan
+    from:
+      field: stan
+    to:
+      field: stan
+  - id: rule_txn_timestamp
+    from:
+      field: txn_timestamp
+    to:
+      field: txn_timestamp
+  - id: rule_pan
+    from:
+      field: pan
+    to:
+      field: pan
+  - id: rule_bin
+    from:
+      field: pan
+    to:
+      field: bin
+    transform:
+      fn: derive_bin
+      args:
+        length: 6
+  - id: rule_amount_minor
+    from:
+      field: amount_minor
+    to:
+      field: amount_minor
+  - id: rule_currency
+    from:
+      field: currency_numeric
+    to:
+      field: currency_alpha
+    transform:
+      fn: iso4217_numeric_to_alpha
+  - id: rule_auth_code
+    from:
+      field: auth_code
+    to:
+      field: auth_code
+  - id: rule_merchant_id
+    to:
+      field: merchant_id
+    choose_from:
+      - when: "merchant_number != null"
+        from:
+          field: merchant_number
+      - when: "acceptor_id != null"
+        from:
+          field: acceptor_id
+      - when: "true"
+        const: UNKNOWN
+  - id: rule_channel
+    to:
+      field: channel
+    choose_from:
+      - when: "merchant_number != null"
+        const: POS
+      - when: "true"
+        const: UNKNOWN
+  - id: rule_approval_status
+    to:
+      field: approval_status
+    const: PENDING
+  - id: rule_response_code
+    to:
+      field: response_code
+    const: "00"

--- a/definitions/messages/discover_iso8583_auth_v1.yaml
+++ b/definitions/messages/discover_iso8583_auth_v1.yaml
@@ -1,0 +1,17 @@
+id: discover_iso8583_auth_v1
+name: Discover ISO8583 Authorization Request
+version: "1.0"
+standard: iso8583
+layout:
+  - ref: mti
+  - ref: pan
+  - ref: amount_minor
+  - ref: currency_numeric
+  - ref: stan
+  - ref: auth_code
+  - ref: merchant_number
+  - ref: acceptor_id
+  - ref: txn_timestamp
+io_binding:
+  format_kind: iso8583
+  bindings: []

--- a/definitions/messages/internal_payment_v1.yaml
+++ b/definitions/messages/internal_payment_v1.yaml
@@ -1,0 +1,32 @@
+id: internal_payment_v1
+name: Internal Payment Request
+version: "1.0"
+standard: internal
+layout:
+  - group: request
+    children:
+      - ref: mti
+      - ref: stan
+      - ref: txn_timestamp
+  - group: card
+    children:
+      - ref: pan
+      - ref: bin
+  - group: amount
+    children:
+      - ref: amount_minor
+      - ref: currency_alpha
+  - group: merchant
+    children:
+      - ref: merchant_id
+      - ref: channel
+  - group: decision
+    children:
+      - ref: approval_status
+      - ref: response_code
+      - ref: auth_code
+io_binding:
+  format_kind: json
+  bindings:
+    - layout_ref: request.mti
+      json_path: $.request.mti

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "iso-mapper-prototype",
+  "version": "1.0.0",
+  "description": "Config-driven mapping engine prototype",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "ts-node src/server.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "yaml": "^2.3.4",
+    "glob": "^10.3.3"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.19",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.3"
+  }
+}

--- a/src/conditions.ts
+++ b/src/conditions.ts
@@ -1,0 +1,41 @@
+export type ParsedCondition =
+  | { kind: "true" }
+  | { kind: "null_check"; field: string; operator: "==" | "!=" };
+
+export function parseCondition(condition: string): ParsedCondition | undefined {
+  const trimmed = condition.trim();
+  if (trimmed === "true") {
+    return { kind: "true" };
+  }
+
+  const match = trimmed.match(/^([a-zA-Z0-9_]+)\s*(==|!=)\s*null$/);
+  if (match) {
+    const [, field, operator] = match;
+    return {
+      kind: "null_check",
+      field,
+      operator: operator as "==" | "!=",
+    };
+  }
+
+  return undefined;
+}
+
+export function evaluateCondition(
+  parsed: ParsedCondition,
+  input: Record<string, unknown>
+): boolean {
+  switch (parsed.kind) {
+    case "true":
+      return true;
+    case "null_check": {
+      const value = input[parsed.field];
+      if (parsed.operator === "==") {
+        return value == null;
+      }
+      return value != null;
+    }
+    default:
+      return false;
+  }
+}

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,0 +1,278 @@
+import {
+  DefinitionsIndex,
+  MappingExecutionResult,
+  MappingRule,
+  MappingSet,
+  TraceEntry,
+} from "./types";
+import { validateMappingSet } from "./validator";
+import { parseCondition, evaluateCondition } from "./conditions";
+import { executeTransform } from "./transformRegistry";
+
+function getFieldDefinition(index: DefinitionsIndex, fieldId: string) {
+  return index.fieldsById.get(fieldId);
+}
+
+function validateValueAgainstField(
+  fieldId: string,
+  value: unknown,
+  index: DefinitionsIndex
+): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const field = getFieldDefinition(index, fieldId);
+  if (!field) {
+    return undefined;
+  }
+
+  switch (field.type) {
+    case "string":
+    case "date":
+    case "datetime":
+      if (typeof value !== "string") {
+        return `Field ${fieldId} expected string-compatible value but received ${typeof value}`;
+      }
+      break;
+    case "integer":
+      if (typeof value !== "number" || !Number.isInteger(value)) {
+        return `Field ${fieldId} expected integer but received ${typeof value}`;
+      }
+      break;
+    case "decimal":
+      if (typeof value !== "number") {
+        return `Field ${fieldId} expected decimal number but received ${typeof value}`;
+      }
+      break;
+    case "boolean":
+      if (typeof value !== "boolean") {
+        return `Field ${fieldId} expected boolean but received ${typeof value}`;
+      }
+      break;
+    default:
+      break;
+  }
+
+  return undefined;
+}
+
+function executeRule(
+  rule: MappingRule,
+  input: Record<string, unknown>,
+  output: Record<string, unknown>,
+  warnings: string[],
+  trace: TraceEntry[]
+) {
+  if ("choose_from" in rule && rule.choose_from) {
+    executeConditionalRule(rule, input, output, warnings, trace);
+    return;
+  }
+
+  if ("transform" in rule && rule.transform) {
+    executeTransformRule(rule, input, output, warnings, trace);
+    return;
+  }
+
+  if ("const" in rule && rule.const !== undefined) {
+    executeConstRule(rule, output, trace);
+    return;
+  }
+
+  if ("from" in rule && rule.from) {
+    executeDirectRule(rule, input, output, warnings, trace);
+  }
+}
+
+function executeDirectRule(
+  rule: MappingRule,
+  input: Record<string, unknown>,
+  output: Record<string, unknown>,
+  warnings: string[],
+  trace: TraceEntry[]
+) {
+  if (!("from" in rule) || !rule.from) {
+    return;
+  }
+  const value = input[rule.from.field];
+  if (value === undefined) {
+    warnings.push(
+      `Direct rule ${rule.id ?? "<unnamed>"}: source field ${rule.from.field} is missing in input`
+    );
+  }
+  output[rule.to.field] = value;
+  trace.push({
+    ruleId: rule.id,
+    type: "direct",
+    fromField: rule.from.field,
+    toField: rule.to.field,
+  });
+}
+
+function executeTransformRule(
+  rule: MappingRule,
+  input: Record<string, unknown>,
+  output: Record<string, unknown>,
+  warnings: string[],
+  trace: TraceEntry[]
+) {
+  if (!("from" in rule) || !rule.from || !rule.transform) {
+    return;
+  }
+  const value = input[rule.from.field];
+  if (value === undefined) {
+    warnings.push(
+      `Transform rule ${rule.id ?? "<unnamed>"}: source field ${rule.from.field} is missing in input`
+    );
+  }
+  try {
+    const result = executeTransform(rule.transform.fn, value, rule.transform.args);
+    if (result === undefined) {
+      warnings.push(
+        `Transform rule ${rule.id ?? "<unnamed>"}: transform ${rule.transform.fn} returned undefined`
+      );
+    }
+    output[rule.to.field] = result;
+  } catch (error) {
+    warnings.push(
+      `Transform rule ${rule.id ?? "<unnamed>"}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    output[rule.to.field] = undefined;
+  }
+  trace.push({
+    ruleId: rule.id,
+    type: "transform",
+    fromField: rule.from.field,
+    toField: rule.to.field,
+    transformFn: rule.transform.fn,
+  });
+}
+
+function executeConstRule(
+  rule: MappingRule,
+  output: Record<string, unknown>,
+  trace: TraceEntry[]
+) {
+  if (!("const" in rule)) {
+    return;
+  }
+  output[rule.to.field] = rule.const;
+  trace.push({
+    ruleId: rule.id,
+    type: "const",
+    toField: rule.to.field,
+  });
+}
+
+function executeConditionalRule(
+  rule: MappingRule,
+  input: Record<string, unknown>,
+  output: Record<string, unknown>,
+  warnings: string[],
+  trace: TraceEntry[]
+) {
+  if (!("choose_from" in rule) || !rule.choose_from) {
+    return;
+  }
+
+  let matched = false;
+  for (const option of rule.choose_from) {
+    const parsed = parseCondition(option.when);
+    if (!parsed) {
+      warnings.push(
+        `Conditional rule ${rule.id ?? "<unnamed>"}: unsupported condition '${option.when}'`
+      );
+      continue;
+    }
+    if (!evaluateCondition(parsed, input)) {
+      continue;
+    }
+    matched = true;
+    if (option.from?.field) {
+      const value = input[option.from.field];
+      if (value === undefined) {
+        warnings.push(
+          `Conditional rule ${rule.id ?? "<unnamed>"}: source field ${option.from.field} is missing in input`
+        );
+      }
+      output[rule.to.field] = value;
+    } else {
+      output[rule.to.field] = option.const;
+    }
+    break;
+  }
+
+  if (!matched) {
+    warnings.push(
+      `Conditional rule ${rule.id ?? "<unnamed>"}: no conditions matched`
+    );
+  }
+
+  trace.push({
+    ruleId: rule.id,
+    type: "conditional",
+    toField: rule.to.field,
+  });
+}
+
+export function executeMappingSet(
+  mappingSet: MappingSet,
+  input: Record<string, unknown>,
+  index: DefinitionsIndex
+): MappingExecutionResult {
+  const validation = validateMappingSet(mappingSet, index);
+  if (validation.errors.length > 0) {
+    return {
+      valid: false,
+      output: {},
+      errors: validation.errors,
+      warnings: validation.warnings,
+      trace: [],
+    };
+  }
+
+  const warnings: string[] = [...validation.warnings];
+  const errors: string[] = [];
+  const output: Record<string, unknown> = {};
+  const trace: TraceEntry[] = [];
+
+  for (const rule of mappingSet.mappings) {
+    executeRule(rule, input, output, warnings, trace);
+  }
+
+  for (const [fieldId, value] of Object.entries(output)) {
+    const warning = validateValueAgainstField(fieldId, value, index);
+    if (warning) {
+      warnings.push(warning);
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    output,
+    warnings,
+    errors,
+    trace,
+  };
+}
+
+export function executeMappingSetById(
+  mappingSetId: string,
+  input: Record<string, unknown>,
+  index: DefinitionsIndex
+): MappingExecutionResult {
+  const mappingSet = index.mappingSetsById.get(mappingSetId);
+  if (!mappingSet) {
+    return {
+      valid: false,
+      output: {},
+      warnings: [],
+      errors: [`Mapping set ${mappingSetId} not found`],
+      trace: [],
+    };
+  }
+
+  return executeMappingSet(mappingSet, input, index);
+}

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,0 +1,98 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { glob } from "glob";
+import YAML from "yaml";
+import {
+  DefinitionsIndex,
+  FieldDefinition,
+  MappingSet,
+  MessageDefinition,
+} from "./types";
+
+async function readDefinitionFile<T>(filePath: string): Promise<T> {
+  const raw = await fs.readFile(filePath, "utf8");
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === ".yaml" || ext === ".yml") {
+    return YAML.parse(raw) as T;
+  }
+  if (ext === ".json") {
+    return JSON.parse(raw) as T;
+  }
+  throw new Error(`Unsupported definition file extension: ${filePath}`);
+}
+
+async function loadFields(definitionsDir: string): Promise<FieldDefinition[]> {
+  const yamlPath = path.join(definitionsDir, "fields.yaml");
+  const ymlPath = path.join(definitionsDir, "fields.yml");
+  const jsonPath = path.join(definitionsDir, "fields.json");
+
+  for (const candidate of [yamlPath, ymlPath, jsonPath]) {
+    try {
+      await fs.access(candidate);
+      return readDefinitionFile<FieldDefinition[]>(candidate);
+    } catch {
+      continue;
+    }
+  }
+
+  throw new Error("fields definition file not found");
+}
+
+async function loadMessages(definitionsDir: string): Promise<MessageDefinition[]> {
+  const files = await glob("**/*.@(yaml|yml|json)", {
+    cwd: path.join(definitionsDir, "messages"),
+    absolute: true,
+    nodir: true,
+  });
+
+  const results: MessageDefinition[] = [];
+  for (const file of files) {
+    const message = await readDefinitionFile<MessageDefinition>(file);
+    results.push(message);
+  }
+  return results;
+}
+
+async function loadMappingSets(definitionsDir: string): Promise<MappingSet[]> {
+  const files = await glob("**/*.@(yaml|yml|json)", {
+    cwd: path.join(definitionsDir, "mappings"),
+    absolute: true,
+    nodir: true,
+  });
+
+  const results: MappingSet[] = [];
+  for (const file of files) {
+    const mappingSet = await readDefinitionFile<MappingSet>(file);
+    results.push(mappingSet);
+  }
+  return results;
+}
+
+export async function loadDefinitions(definitionsDir: string): Promise<DefinitionsIndex> {
+  const [fields, messages, mappingSets] = await Promise.all([
+    loadFields(definitionsDir),
+    loadMessages(definitionsDir),
+    loadMappingSets(definitionsDir),
+  ]);
+
+  const fieldsById = new Map<string, FieldDefinition>();
+  for (const field of fields) {
+    fieldsById.set(field.id, field);
+  }
+
+  const messagesById = new Map<string, MessageDefinition>();
+  for (const message of messages) {
+    messagesById.set(message.id, message);
+  }
+
+  const mappingSetsById = new Map<string, MappingSet>();
+  for (const mappingSet of mappingSets) {
+    mappingSetsById.set(mappingSet.id, mappingSet);
+  }
+
+  return {
+    fieldsById,
+    messagesById,
+    mappingSetsById,
+  };
+}

--- a/src/messageUtils.ts
+++ b/src/messageUtils.ts
@@ -1,0 +1,22 @@
+import { MessageDefinition, MessageLayoutItem } from "./types";
+
+export function collectFieldsFromLayout(layout: MessageLayoutItem[]): string[] {
+  const fields: string[] = [];
+
+  const visit = (items: MessageLayoutItem[]) => {
+    for (const item of items) {
+      if ("ref" in item) {
+        fields.push(item.ref);
+      } else if ("children" in item) {
+        visit(item.children);
+      }
+    }
+  };
+
+  visit(layout);
+  return fields;
+}
+
+export function getMessageFieldSet(message: MessageDefinition): Set<string> {
+  return new Set(collectFieldsFromLayout(message.layout));
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,90 @@
+import express, { Request, Response } from "express";
+import path from "path";
+import { loadDefinitions } from "./loader";
+import { DefinitionsIndex } from "./types";
+import { validateMappingSet } from "./validator";
+import { executeMappingSetById } from "./executor";
+
+const app = express();
+app.use(express.json());
+
+let definitionsIndex: DefinitionsIndex | null = null;
+
+async function bootstrapDefinitions(): Promise<void> {
+  const definitionsDir = path.join(__dirname, "..", "definitions");
+  definitionsIndex = await loadDefinitions(definitionsDir);
+}
+
+function ensureDefinitionsLoaded(res: Response): DefinitionsIndex | null {
+  if (!definitionsIndex) {
+    res.status(503).json({ error: "Definitions not loaded" });
+    return null;
+  }
+  return definitionsIndex;
+}
+
+app.get("/health", (_req: Request, res: Response) => {
+  res.json({ status: "ok" });
+});
+
+app.get("/mappings/:id", (req: Request, res: Response) => {
+  const index = ensureDefinitionsLoaded(res);
+  if (!index) {
+    return;
+  }
+  const mappingSet = index.mappingSetsById.get(req.params.id);
+  if (!mappingSet) {
+    res.status(404).json({ error: `Mapping set ${req.params.id} not found` });
+    return;
+  }
+  res.json(mappingSet);
+});
+
+app.post("/validate/:id", (req: Request, res: Response) => {
+  const index = ensureDefinitionsLoaded(res);
+  if (!index) {
+    return;
+  }
+  const mappingSet = index.mappingSetsById.get(req.params.id);
+  if (!mappingSet) {
+    res.status(404).json({ error: `Mapping set ${req.params.id} not found` });
+    return;
+  }
+  const result = validateMappingSet(mappingSet, index);
+  res.json(result);
+});
+
+app.post("/run", (req: Request, res: Response) => {
+  const index = ensureDefinitionsLoaded(res);
+  if (!index) {
+    return;
+  }
+  const { mapping_set_id: mappingSetId, input } = req.body ?? {};
+  if (!mappingSetId || typeof mappingSetId !== "string") {
+    res.status(400).json({ error: "mapping_set_id is required" });
+    return;
+  }
+  if (typeof input !== "object" || input === null) {
+    res.status(400).json({ error: "input must be an object" });
+    return;
+  }
+
+  const result = executeMappingSetById(mappingSetId, input, index);
+  res.json(result);
+});
+
+async function start() {
+  try {
+    await bootstrapDefinitions();
+  } catch (error) {
+    console.error("Failed to load definitions", error);
+    process.exit(1);
+  }
+
+  const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+  app.listen(port, () => {
+    console.log(`ISO Mapper prototype listening on port ${port}`);
+  });
+}
+
+start();

--- a/src/transformRegistry.ts
+++ b/src/transformRegistry.ts
@@ -1,0 +1,54 @@
+export type TransformFn = (
+  value: unknown,
+  args?: Record<string, unknown>
+) => unknown;
+
+const registry: Record<string, TransformFn> = {
+  minor_to_major: (value, args) => {
+    if (typeof value !== "number") {
+      return undefined;
+    }
+    const scale = typeof args?.scale === "number" ? args.scale : 2;
+    const divisor = Math.pow(10, scale);
+    return value / divisor;
+  },
+  iso4217_numeric_to_alpha: (value) => {
+    if (typeof value !== "string") {
+      return undefined;
+    }
+    const lookup: Record<string, string> = {
+      "840": "USD",
+      "826": "GBP",
+      "978": "EUR",
+      "036": "AUD",
+    };
+    return lookup[value] ?? undefined;
+  },
+  derive_bin: (value, args) => {
+    if (typeof value !== "string") {
+      return undefined;
+    }
+    const length = typeof args?.length === "number" ? args.length : 6;
+    return value.slice(0, length);
+  },
+};
+
+export function hasTransform(name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(registry, name);
+}
+
+export function executeTransform(
+  name: string,
+  value: unknown,
+  args?: Record<string, unknown>
+): unknown {
+  const fn = registry[name];
+  if (!fn) {
+    throw new Error(`Transform function not found: ${name}`);
+  }
+  return fn(value, args);
+}
+
+export function listTransforms(): string[] {
+  return Object.keys(registry);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,144 @@
+export type FieldType = "string" | "integer" | "decimal" | "boolean" | "date" | "datetime";
+export type FieldStructure = "scalar" | "object" | "repeated";
+
+export interface FieldConstraints {
+  min?: number;
+  max?: number;
+  min_length?: number;
+  max_length?: number;
+  length?: number;
+  pattern?: string;
+  enum?: string[];
+}
+
+export interface FieldDefinition {
+  id: string;
+  label?: string;
+  description?: string;
+  type: FieldType;
+  structure?: FieldStructure;
+  constraints?: FieldConstraints;
+  semantic_tags?: string[];
+}
+
+export interface MessageLayoutFieldRef {
+  ref: string;
+}
+
+export interface MessageLayoutGroup {
+  group: string;
+  children: MessageLayoutItem[];
+}
+
+export type MessageLayoutItem = MessageLayoutFieldRef | MessageLayoutGroup;
+
+export interface MessageDefinition {
+  id: string;
+  name?: string;
+  version: string;
+  standard?: string;
+  profile?: string;
+  layout: MessageLayoutItem[];
+  io_binding?: {
+    format_kind: string;
+    adapter?: string;
+    bindings?: Array<{
+      layout_ref: string;
+      iso8583_mti?: boolean;
+      iso8583_de?: number;
+      json_path?: string;
+      xpath?: string;
+    }>;
+  };
+}
+
+export interface MappingEndpoint {
+  field: string;
+}
+
+export interface TransformInvocation {
+  fn: string;
+  args?: Record<string, unknown>;
+}
+
+export interface ChooseOption {
+  when: string;
+  from?: MappingEndpoint;
+  const?: unknown;
+}
+
+export interface BaseMappingRule {
+  id?: string;
+  to: MappingEndpoint;
+}
+
+export interface DirectMappingRule extends BaseMappingRule {
+  from: MappingEndpoint;
+  transform?: undefined;
+  choose_from?: undefined;
+  const?: undefined;
+}
+
+export interface TransformMappingRule extends BaseMappingRule {
+  from: MappingEndpoint;
+  transform: TransformInvocation;
+  choose_from?: undefined;
+  const?: undefined;
+}
+
+export interface ConditionalMappingRule extends BaseMappingRule {
+  from?: undefined;
+  transform?: undefined;
+  choose_from: ChooseOption[];
+  const?: undefined;
+}
+
+export interface ConstMappingRule extends BaseMappingRule {
+  from?: undefined;
+  transform?: undefined;
+  choose_from?: undefined;
+  const: unknown;
+}
+
+export type MappingRule =
+  | DirectMappingRule
+  | TransformMappingRule
+  | ConditionalMappingRule
+  | ConstMappingRule;
+
+export interface MappingSet {
+  id: string;
+  description?: string;
+  from_message: string;
+  to_message: string;
+  version: string;
+  mappings: MappingRule[];
+}
+
+export interface ValidationResult {
+  errors: string[];
+  warnings: string[];
+}
+
+export interface TraceEntry {
+  ruleId?: string;
+  type: "direct" | "transform" | "conditional" | "const";
+  fromField?: string;
+  toField: string;
+  transformFn?: string;
+  notes?: string;
+}
+
+export interface MappingExecutionResult {
+  valid: boolean;
+  output: Record<string, unknown>;
+  warnings: string[];
+  errors: string[];
+  trace: TraceEntry[];
+}
+
+export interface DefinitionsIndex {
+  fieldsById: Map<string, FieldDefinition>;
+  messagesById: Map<string, MessageDefinition>;
+  mappingSetsById: Map<string, MappingSet>;
+}

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,0 +1,144 @@
+import {
+  DefinitionsIndex,
+  MappingRule,
+  MappingSet,
+  ValidationResult,
+} from "./types";
+import { getMessageFieldSet } from "./messageUtils";
+import { hasTransform } from "./transformRegistry";
+import { parseCondition } from "./conditions";
+
+export function validateMappingSet(
+  mappingSet: MappingSet,
+  index: DefinitionsIndex
+): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const sourceMessage = index.messagesById.get(mappingSet.from_message);
+  if (!sourceMessage) {
+    errors.push(
+      `Mapping set ${mappingSet.id}: source message ${mappingSet.from_message} not found`
+    );
+  }
+
+  const targetMessage = index.messagesById.get(mappingSet.to_message);
+  if (!targetMessage) {
+    errors.push(
+      `Mapping set ${mappingSet.id}: target message ${mappingSet.to_message} not found`
+    );
+  }
+
+  const sourceFields = sourceMessage ? getMessageFieldSet(sourceMessage) : undefined;
+  const targetFields = targetMessage ? getMessageFieldSet(targetMessage) : undefined;
+
+  for (const rule of mappingSet.mappings) {
+    validateRule(rule, {
+      mappingSet,
+      errors,
+      warnings,
+      index,
+      sourceFields,
+      targetFields,
+    });
+  }
+
+  return { errors, warnings };
+}
+
+interface RuleValidationContext {
+  mappingSet: MappingSet;
+  errors: string[];
+  warnings: string[];
+  index: DefinitionsIndex;
+  sourceFields?: Set<string>;
+  targetFields?: Set<string>;
+}
+
+function validateRule(rule: MappingRule, ctx: RuleValidationContext) {
+  const { mappingSet, errors, index, sourceFields, targetFields } = ctx;
+  const toField = rule.to?.field;
+
+  if (!toField) {
+    errors.push(
+      `Mapping set ${mappingSet.id}: rule ${rule.id ?? "<unnamed>"} is missing a target field`
+    );
+    return;
+  }
+
+  if (targetFields && !targetFields.has(toField)) {
+    errors.push(
+      `Mapping set ${mappingSet.id}: target field ${toField} not found in message ${mappingSet.to_message}`
+    );
+  }
+
+  if (!index.fieldsById.has(toField)) {
+    errors.push(
+      `Mapping set ${mappingSet.id}: target field ${toField} is not defined in fields catalog`
+    );
+  }
+
+  if ("from" in rule && rule.from) {
+    const fromField = rule.from.field;
+    if (sourceFields && !sourceFields.has(fromField)) {
+      errors.push(
+        `Mapping set ${mappingSet.id}: source field ${fromField} not found in message ${mappingSet.from_message}`
+      );
+    }
+    if (!index.fieldsById.has(fromField)) {
+      errors.push(
+        `Mapping set ${mappingSet.id}: source field ${fromField} is not defined in fields catalog`
+      );
+    }
+  }
+
+  if ("transform" in rule && rule.transform) {
+    if (!hasTransform(rule.transform.fn)) {
+      errors.push(
+        `Mapping set ${mappingSet.id}: transform ${rule.transform.fn} referenced in rule ${rule.id ?? "<unnamed>"} is not registered`
+      );
+    }
+  }
+
+  if ("choose_from" in rule && rule.choose_from) {
+    if (rule.choose_from.length === 0) {
+      errors.push(
+        `Mapping set ${mappingSet.id}: conditional rule ${rule.id ?? "<unnamed>"} has no options`
+      );
+    }
+
+    for (const option of rule.choose_from) {
+      const parsed = parseCondition(option.when);
+      if (!parsed) {
+        errors.push(
+          `Mapping set ${mappingSet.id}: conditional rule ${rule.id ?? "<unnamed>"} has unsupported condition '${option.when}'`
+        );
+      } else if (parsed.kind === "null_check") {
+        if (ctx.sourceFields && !ctx.sourceFields.has(parsed.field)) {
+          errors.push(
+            `Mapping set ${mappingSet.id}: conditional rule ${rule.id ?? "<unnamed>"} references unknown field ${parsed.field} in condition`
+          );
+        }
+      }
+
+      if (option.from?.field) {
+        if (sourceFields && !sourceFields.has(option.from.field)) {
+          errors.push(
+            `Mapping set ${mappingSet.id}: conditional rule ${rule.id ?? "<unnamed>"} references source field ${option.from.field} not present in message ${mappingSet.from_message}`
+          );
+        }
+        if (!index.fieldsById.has(option.from.field)) {
+          errors.push(
+            `Mapping set ${mappingSet.id}: conditional rule ${rule.id ?? "<unnamed>"} references undefined field ${option.from.field}`
+          );
+        }
+      }
+
+      if (option.from === undefined && option.const === undefined) {
+        errors.push(
+          `Mapping set ${mappingSet.id}: conditional rule ${rule.id ?? "<unnamed>"} option is missing 'from' or 'const'`
+        );
+      }
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- scaffold a TypeScript-based ISO mapper prototype with config-driven loaders, validators, transforms, and executor
- expose Express HTTP endpoints for health checks, mapping inspection, validation, and execution
- add sample field, message, and mapping definitions plus documentation for running the prototype

## Testing
- npm run build *(fails: unable to download npm packages in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f05fe1a08321855436b88fda3385)